### PR TITLE
#248 medium風エディタの開発

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -9,6 +9,21 @@
 .medium-insert-images figure img, .mediumInsert figure img {
   max-width: 400px;
 }
+
+/* custom embed addon */
+.medium-insert-embed .plain_url {
+  display: none;
+}
+.medium-insert-embeds.medium-insert-embeds-left, .medium-insert-embeds-left.mediumInsert-embeds {
+    float: none;
+    text-align: left;
+    width: 100%;
+}
+.medium-insert-embeds.medium-insert-embeds-right, .medium-insert-embeds-right.mediumInsert-embeds {
+    float: none;
+    text-align: right;
+    width: 100%;
+}
 /*
 .medium-editor-insert-plugin .medium-insert-buttons .medium-insert-buttons-addons li:nth-child(2) button{
   display: none;

--- a/css/custom.css
+++ b/css/custom.css
@@ -14,16 +14,16 @@
 .medium-insert-embed .plain_url {
   display: none;
 }
-.medium-insert-embeds.medium-insert-embeds-left, .medium-insert-embeds-left.mediumInsert-embeds {
-    float: none;
-    text-align: left;
-    width: 100%;
+
+iframe {
+  width: 400px;
 }
-.medium-insert-embeds.medium-insert-embeds-right, .medium-insert-embeds-right.mediumInsert-embeds {
-    float: none;
-    text-align: right;
-    width: 100%;
+
+.medium-editor-element {
+  overflow-y: auto;
+  resize: none;
 }
+
 /*
 .medium-editor-insert-plugin .medium-insert-buttons .medium-insert-buttons-addons li:nth-child(2) button{
   display: none;

--- a/js/q2a-embeds.js
+++ b/js/q2a-embeds.js
@@ -1,0 +1,680 @@
+;(function ($, window, document, undefined) {
+
+    'use strict';
+
+    /** Default values */
+    var pluginName = 'mediumInsert',
+        addonName = 'Embeds2', // first char is uppercase
+        defaults = {
+            label: '<span class="fa fa-youtube-play"></span>',
+            placeholder: 'YouTubeの動画URLを貼ってください。',
+            captions: false,
+            captionPlaceholder: 'Type caption (optional)',
+            storeMeta: false,
+            styles: {
+                wide: {
+                    label: '<span class="fa fa-align-justify"></span>'
+                    // added: function ($el) {},
+                    // removed: function ($el) {}
+                },
+                left: {
+                    label: '<span class="fa fa-align-left"></span>'
+                    // added: function ($el) {},
+                    // removed: function ($el) {}
+                },
+                right: {
+                    label: '<span class="fa fa-align-right"></span>'
+                    // added: function ($el) {},
+                    // removed: function ($el) {}
+                }
+            },
+            actions: {
+                remove: {
+                    label: '<span class="fa fa-times"></span>',
+                    clicked: function () {
+                        var $event = $.Event('keydown');
+
+                        $event.which = 8;
+                        $(document).trigger($event);
+                    }
+                }
+            },
+            parseOnPaste: false
+        };
+
+    /**
+     * Q2AEmbeds object
+     *
+     * Sets options, variables and calls init() function
+     *
+     * @constructor
+     * @param {DOM} el - DOM element to init the plugin on
+     * @param {object} options - Options to override defaults
+     * @return {void}
+     */
+
+    function Q2AEmbeds (el, options) {
+        this.el = el;
+        this.$el = $(el);
+        this.templates = window.MediumInsert.Templates;
+        this.core = this.$el.data('plugin_'+ pluginName);
+
+        this.options = $.extend(true, {}, defaults, options);
+        
+        // Extend editor's functions
+        if (this.core.getEditor()) {
+            this.core.getEditor()._serializePreEmbeds = this.core.getEditor().serialize;
+            this.core.getEditor().serialize = this.editorSerialize;
+        }
+        
+        this._defaults = defaults;
+        this._name = pluginName;
+
+        this.init();
+    }
+
+    /**
+     * Initialization
+     *
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.init = function () {
+        var $embeds = this.$el.find('.medium-insert-embeds');
+        
+        $embeds.attr('contenteditable', false);
+        $embeds.each(function () {
+            if ($(this).find('.medium-insert-embeds-overlay').length === 0) {
+                $(this).append($('<div />').addClass('medium-insert-embeds-overlay'));
+            }
+        });
+
+        this.events();
+        this.backwardsCompatibility();
+    };
+
+    /**
+     * Event listeners
+     *
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.events = function () {
+        $(document)
+            .on('click', $.proxy(this, 'unselectEmbed'))
+            .on('keydown', $.proxy(this, 'removeEmbed'))
+            .on('click', '.medium-insert-embeds-toolbar .medium-editor-action', $.proxy(this, 'toolbarAction'))
+            .on('click', '.medium-insert-embeds-toolbar2 .medium-editor-action', $.proxy(this, 'toolbar2Action'));
+
+        this.$el
+            .on('keyup click paste', $.proxy(this, 'togglePlaceholder'))
+            .on('keydown', $.proxy(this, 'processLink'))
+            .on('click', '.medium-insert-embeds-overlay', $.proxy(this, 'selectEmbed'))
+            .on('contextmenu', '.medium-insert-embeds-placeholder', $.proxy(this, 'fixRightClickOnPlaceholder'));
+
+        if (this.options.parseOnPaste) {
+            this.$el
+                .on('paste', $.proxy(this, 'processPasted'));
+        }
+
+        $(window)
+            .on('resize', $.proxy(this, 'autoRepositionToolbars'));
+
+    };
+    
+    /**
+     * Replace v0.* class names with new ones, wrap embedded content to new structure
+     *
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.backwardsCompatibility = function () {
+        var that = this;
+
+        this.$el.find('.mediumInsert-embeds')
+            .removeClass('mediumInsert-embeds')
+            .addClass('medium-insert-embeds');
+
+        this.$el.find('.medium-insert-embeds').each(function () {
+            if ($(this).find('.medium-insert-embed').length === 0) {
+                $(this).after(that.templates['src/js/templates/embeds-wrapper.hbs']({
+                    html: $(this).html()
+                }));
+                $(this).remove();
+            }
+        });
+    };
+    
+    /**
+     * Extend editor's serialize function
+     *
+     * @return {object} Serialized data
+     */
+
+    Q2AEmbeds.prototype.editorSerialize = function () {
+        var data = this._serializePreEmbeds();
+
+        $.each(data, function (key) {
+            var $data = $('<div />').html(data[key].value);
+
+            $data.find('.medium-insert-embeds').removeAttr('contenteditable');
+            $data.find('.medium-insert-embeds-overlay').remove();
+
+            data[key].value = $data.html();
+        });
+
+        return data;
+    };
+    
+    /**
+     * Add embedded element
+     *
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.add = function () {
+        var $place = this.$el.find('.medium-insert-active');
+
+        // Fix #132
+        // Make sure that the content of the paragraph is empty and <br> is wrapped in <p></p> to avoid Firefox problems
+        $place.html(this.templates['src/js/templates/core-empty-line.hbs']().trim());
+
+        // Replace paragraph with div to prevent #124 issue with pasting in Chrome,
+        // because medium editor wraps inserted content into paragraph and paragraphs can't be nested
+        if ($place.is('p')) {
+            $place.replaceWith('<div class="medium-insert-active">' + $place.html() + '</div>');
+            $place = this.$el.find('.medium-insert-active');
+            this.core.moveCaret($place);
+        }
+
+        $place.addClass('medium-insert-embeds medium-insert-embeds-input medium-insert-embeds-active');
+
+        this.togglePlaceholder({ target: $place.get(0) });
+
+        $place.click();
+        this.core.hideButtons();
+    };
+    
+    /**
+     * Toggles placeholder
+     *
+     * @param {Event} e
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.togglePlaceholder = function (e) {
+        var $place = $(e.target),
+            selection = window.getSelection(),
+            range, $current, text;
+
+        if (!selection || selection.rangeCount === 0) {
+            return;
+        }
+
+        range = selection.getRangeAt(0);
+        $current = $(range.commonAncestorContainer);
+
+        if ($current.hasClass('medium-insert-embeds-active')) {
+            $place = $current;
+        } else if ($current.closest('.medium-insert-embeds-active').length) {
+            $place = $current.closest('.medium-insert-embeds-active');
+        }
+
+        if ($place.hasClass('medium-insert-embeds-active')) {
+
+            text = $place.text().trim();
+
+            if (text === '' && $place.hasClass('medium-insert-embeds-placeholder') === false) {
+                $place
+                    .addClass('medium-insert-embeds-placeholder')
+                    .attr('data-placeholder', this.options.placeholder);
+            } else if (text !== '' && $place.hasClass('medium-insert-embeds-placeholder')) {
+                $place
+                    .removeClass('medium-insert-embeds-placeholder')
+                    .removeAttr('data-placeholder');
+            }
+
+        } else {
+            this.$el.find('.medium-insert-embeds-active').remove();
+        }
+    };
+    
+    /**
+     * Right click on placeholder in Chrome selects whole line. Fix this by placing caret at the end of line
+     *
+     * @param {Event} e
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.fixRightClickOnPlaceholder = function (e) {
+        this.core.moveCaret($(e.target));
+    };
+
+    /**
+     * Process link
+     *
+     * @param {Event} e
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.processLink = function (e) {
+        var $place = this.$el.find('.medium-insert-embeds-active'),
+            url;
+
+        if (!$place.length) {
+            return;
+        }
+
+        url = $place.text().trim();
+
+        // Return empty placeholder on backspace, delete or enter
+        if (url === '' && [8, 46, 13].indexOf(e.which) !== -1) {
+            $place.remove();
+            return;
+        }
+
+        if (e.which === 13) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            this.parseUrl(url);
+        }
+    };
+
+    /**
+     * Process Pasted
+     *
+     * @param {Event} e
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.processPasted = function (e) {
+        var pastedUrl, linkRegEx;
+        if ($(".medium-insert-embeds-active").length) {
+            return;
+        }
+
+        pastedUrl = e.originalEvent.clipboardData.getData('text');
+        linkRegEx = new RegExp('^(http(s?):)?\/\/','i');
+        if (linkRegEx.test(pastedUrl)) {
+            this.parseUrl(pastedUrl, true);            
+        }
+    };
+    
+    /**
+     * Get HTML using regexp
+     *
+     * @param {string} url
+     * @param {bool} pasted
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.parseUrl = function (url, pasted) {
+        var html;
+
+        if (!(new RegExp(['youtube', 'youtu.be', 'vimeo', 'instagram', 'twitter', 'facebook'].join('|')).test(url))) {
+            $.proxy(this, 'convertBadEmbed', url)();
+            return false;
+        }
+        var plain_url = '<div class="plain_url">'+url+'</div>';
+        
+        html = url.replace(/\n?/g, '')
+            .replace(/^((http(s)?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/(watch\?v=|v\/)?)([a-zA-Z0-9\-_]+)(.*)?$/, '<div class="video video-youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/$7" frameborder="0" allowfullscreen></iframe></div>')
+            .replace(/^https?:\/\/vimeo\.com(\/.+)?\/([0-9]+)$/, '<div class="video video-vimeo"><iframe src="//player.vimeo.com/video/$2" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>')
+            .replace(/^https:\/\/twitter\.com\/(\w+)\/status\/(\d+)\/?$/, '<blockquote class="twitter-tweet" align="center" lang="en"><a href="https://twitter.com/$1/statuses/$2"></a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>')
+            .replace(/^(https:\/\/www\.facebook\.com\/(.*))$/, '<script src="//connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v2.2" async></script><div class="fb-post" data-href="$1"><div class="fb-xfbml-parse-ignore"><a href="$1">Loading Facebook post...</a></div></div>')
+            .replace(/^https?:\/\/instagram\.com\/p\/(.+)\/?$/, '<span class="instagram"><iframe src="//instagram.com/p/$1/embed/" width="612" height="710" frameborder="0" scrolling="no" allowtransparency="true"></iframe></span>');
+
+        if (this.options.storeMeta) {
+            html += '<div class="medium-insert-embeds-meta"><script type="text/json">' + JSON.stringify({}) + '</script></div>';
+        }
+
+        if ((/<("[^"]*"|'[^']*'|[^'">])*>/).test(html) === false) {
+            $.proxy(this, 'convertBadEmbed', url)();
+            return false;
+        }
+        html += plain_url;
+        if (pasted) {
+            this.embed(html, url);
+        } else {
+            this.embed(html);
+        }
+    };
+
+    /**
+     * Add html to page
+     *
+     * @param {string} html
+     * @param {string} pastedUrl
+     * @return {void}
+     */
+
+    Q2AEmbeds.prototype.embed = function (html, pastedUrl) {
+        var $place = this.$el.find('.medium-insert-embeds-active'),
+            $div;
+
+        if (!html) {
+            alert('Incorrect URL format specified');
+            return false;
+        } else {
+            if (html.indexOf('</script>') > -1) {
+                // Store embed code with <script> tag inside wrapper attribute value.
+                // Make nice attribute value escaping using jQuery.
+                $div = $('<div>')
+                    .attr('data-embed-code', $('<div />').text(html).html())
+                    .html(html);
+                html = $('<div>').append($div).html();
+            }
+
+            if (pastedUrl) {
+                // Get the element with the pasted url
+                // place the embed template and remove the pasted text
+                $place = this.$el.find(":not(iframe, script, style)")
+                    .contents().filter(
+                        function () {
+                            return this.nodeType === 3 && this.textContent.indexOf(pastedUrl) > -1;
+                        }).parent();
+
+                $place.after(this.templates['src/js/templates/embeds-wrapper.hbs']({
+                    html: html
+                }));
+                $place.text($place.text().replace(pastedUrl, ''));
+            } else {
+                $place.after(this.templates['src/js/templates/embeds-wrapper.hbs']({
+                    html: html
+                }));
+                $place.remove();
+            }
+
+
+            this.core.triggerInput();
+
+            if (html.indexOf('facebook') !== -1) {
+                if (typeof (FB) !== 'undefined') {
+                    setTimeout(function () {
+                        FB.XFBML.parse();
+                    }, 2000);
+                }
+            }
+        }
+    };
+
+    /**
+     * Convert bad oEmbed content to an actual line.
+     * Instead of displaying the error message we convert the bad embed
+     *
+     * @param {string} content Bad content
+     *
+     * @return {void}
+     */
+    Q2AEmbeds.prototype.convertBadEmbed = function (content) {
+        var $place, $empty, $content,
+            emptyTemplate = this.templates['src/js/templates/core-empty-line.hbs']().trim();
+
+        $place = this.$el.find('.medium-insert-embeds-active');
+
+        // convert embed node to an empty node and insert the bad embed inside
+        $content = $(emptyTemplate);
+        $place.before($content);
+        $place.remove();
+        $content.html(content);
+
+        // add an new empty node right after to simulate Enter press
+        $empty = $(emptyTemplate);
+        $content.after($empty);
+
+        this.core.triggerInput();
+
+        this.core.moveCaret($empty);
+    };
+
+    /**
+     * Select clicked embed
+     *
+     * @param {Event} e
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.selectEmbed = function (e) {
+        var that = this,
+            $embed;
+        if (this.core.options.enabled) {
+            $embed = $(e.target).hasClass('medium-insert-embeds') ? $(e.target) : $(e.target).closest('.medium-insert-embeds');
+
+            $embed.addClass('medium-insert-embeds-selected');
+
+            setTimeout(function () {
+                that.addToolbar();
+
+                if (that.options.captions) {
+                    that.core.addCaption($embed.find('figure'), that.options.captionPlaceholder);
+                }
+            }, 50);
+        }
+    };
+
+    /**
+     * Unselect selected embed
+     *
+     * @param {Event} e
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.unselectEmbed = function (e) {
+        var $el = $(e.target).hasClass('medium-insert-embeds') ? $(e.target) : $(e.target).closest('.medium-insert-embeds'),
+            $embed = this.$el.find('.medium-insert-embeds-selected');
+
+        if ($el.hasClass('medium-insert-embeds-selected')) {
+            $embed.not($el).removeClass('medium-insert-embeds-selected');
+            $('.medium-insert-embeds-toolbar, .medium-insert-embeds-toolbar2').remove();
+            this.core.removeCaptions($el.find('figcaption'));
+
+            if ($(e.target).is('.medium-insert-caption-placeholder') || $(e.target).is('figcaption')) {
+                $el.removeClass('medium-insert-embeds-selected');
+                this.core.removeCaptionPlaceholder($el.find('figure'));
+            }
+            return;
+        }
+
+        $embed.removeClass('medium-insert-embeds-selected');
+        $('.medium-insert-embeds-toolbar, .medium-insert-embeds-toolbar2').remove();
+
+        if ($(e.target).is('.medium-insert-caption-placeholder')) {
+            this.core.removeCaptionPlaceholder($el.find('figure'));
+        } else if ($(e.target).is('figcaption') === false) {
+            this.core.removeCaptions();
+        }
+    };
+
+    /**
+     * Remove embed
+     *
+     * @param {Event} e
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.removeEmbed = function (e) {
+        var $embed, $empty;
+
+        if (e.which === 8 || e.which === 46) {
+            $embed = this.$el.find('.medium-insert-embeds-selected');
+
+            if ($embed.length) {
+                e.preventDefault();
+
+                $('.medium-insert-embeds-toolbar, .medium-insert-embeds-toolbar2').remove();
+
+                $empty = $(this.templates['src/js/templates/core-empty-line.hbs']().trim());
+                $embed.before($empty);
+                $embed.remove();
+
+                // Hide addons
+                this.core.hideAddons();
+
+                this.core.moveCaret($empty);
+                this.core.triggerInput();
+            }
+        }
+    };
+    
+    /**
+     * Adds embed toolbar to editor
+     *
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.addToolbar = function () {
+        var $embed = this.$el.find('.medium-insert-embeds-selected'),
+            active = false,
+            $toolbar, $toolbar2, mediumEditor, toolbarContainer;
+
+        if ($embed.length === 0) {
+            return;
+        }
+
+        mediumEditor = this.core.getEditor();
+        toolbarContainer = mediumEditor.options.elementsContainer || 'body';
+
+        $(toolbarContainer).append(this.templates['src/js/templates/embeds-toolbar.hbs']({
+            styles: this.options.styles,
+            actions: this.options.actions
+        }).trim());
+
+        $toolbar = $('.medium-insert-embeds-toolbar');
+        $toolbar2 = $('.medium-insert-embeds-toolbar2');
+
+        $toolbar.find('button').each(function () {
+            if ($embed.hasClass('medium-insert-embeds-' + $(this).data('action'))) {
+                $(this).addClass('medium-editor-button-active');
+                active = true;
+            }
+        });
+
+        if (active === false) {
+            $toolbar.find('button').first().addClass('medium-editor-button-active');
+        }
+
+        this.repositionToolbars();
+        $toolbar.fadeIn();
+        $toolbar2.fadeIn();
+    };
+
+    Q2AEmbeds.prototype.autoRepositionToolbars = function () {
+        setTimeout(function () {
+            this.repositionToolbars();
+            this.repositionToolbars();
+        }.bind(this), 0);
+    };
+
+    Q2AEmbeds.prototype.repositionToolbars = function () {
+        var $toolbar = $('.medium-insert-embeds-toolbar'),
+            $toolbar2 = $('.medium-insert-embeds-toolbar2'),
+            $embed = this.$el.find('.medium-insert-embeds-selected'),
+            elementsContainer = this.core.getEditor().options.elementsContainer,
+            elementsContainerAbsolute = ['absolute', 'fixed'].indexOf(window.getComputedStyle(elementsContainer).getPropertyValue('position')) > -1,
+            elementsContainerBoundary = elementsContainerAbsolute ? elementsContainer.getBoundingClientRect() : null,
+            containerWidth = $(window).width(),
+            position = {};
+
+        if ($toolbar2.length) {
+            position.top = $embed.offset().top + 2; // 2px - distance from a border
+            position.left = $embed.offset().left + $embed.width() - $toolbar2.width() - 4; // 4px - distance from a border
+
+            if (elementsContainerAbsolute) {
+                position.top += elementsContainer.scrollTop - elementsContainerBoundary.top;
+                position.left -= elementsContainerBoundary.left;
+                containerWidth = $(elementsContainer).width();
+            }
+
+            if (position.left + $toolbar2.width() > containerWidth) {
+                position.left = containerWidth - $toolbar2.width();
+            }
+
+            $toolbar2.css(position);
+        }
+
+        if ($toolbar.length) {
+            position.left = $embed.offset().left + $embed.width() / 2 - $toolbar.width() / 2;
+            position.top = $embed.offset().top - $toolbar.height() - 8 - 2 - 5; // 8px - hight of an arrow under toolbar, 2px - height of an embed outset, 5px - distance from an embed
+
+            if (elementsContainerAbsolute) {
+                position.top += elementsContainer.scrollTop - elementsContainerBoundary.top;
+                position.left -= elementsContainerBoundary.left;
+            }
+
+            if (position.top < 0) {
+                position.top = 0;
+            }
+
+            $toolbar.css(position);
+        }
+    };
+
+    /**
+     * Fires toolbar action
+     *
+     * @param {Event} e
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.toolbarAction = function (e) {
+        var $button = $(e.target).is('button') ? $(e.target) : $(e.target).closest('button'),
+            $li = $button.closest('li'),
+            $ul = $li.closest('ul'),
+            $lis = $ul.find('li'),
+            $embed = this.$el.find('.medium-insert-embeds-selected'),
+            that = this;
+
+        $button.addClass('medium-editor-button-active');
+        $li.siblings().find('.medium-editor-button-active').removeClass('medium-editor-button-active');
+
+        $lis.find('button').each(function () {
+            var className = 'medium-insert-embeds-' + $(this).data('action');
+
+            if ($(this).hasClass('medium-editor-button-active')) {
+                $embed.addClass(className);
+
+                if (that.options.styles[$(this).data('action')].added) {
+                    that.options.styles[$(this).data('action')].added($embed);
+                }
+            } else {
+                $embed.removeClass(className);
+
+                if (that.options.styles[$(this).data('action')].removed) {
+                    that.options.styles[$(this).data('action')].removed($embed);
+                }
+            }
+        });
+
+        this.core.triggerInput();
+    };
+
+    /**
+     * Fires toolbar2 action
+     *
+     * @param {Event} e
+     * @returns {void}
+     */
+
+    Q2AEmbeds.prototype.toolbar2Action = function (e) {
+        var $button = $(e.target).is('button') ? $(e.target) : $(e.target).closest('button'),
+            callback = this.options.actions[$button.data('action')].clicked;
+
+        if (callback) {
+            callback(this.$el.find('.medium-insert-embeds-selected'));
+        }
+
+        this.core.triggerInput();
+    };
+    
+    /** Addon initialization */
+
+    $.fn[pluginName + addonName] = function (options) {
+        return this.each(function () {
+            if (!$.data(this, 'plugin_' + pluginName + addonName)) {
+                $.data(this, 'plugin_' + pluginName + addonName, new Q2AEmbeds(this, options));
+            }
+        });
+    };
+
+})(jQuery, window, document);

--- a/q2a-medium-editor-layer.php
+++ b/q2a-medium-editor-layer.php
@@ -63,6 +63,7 @@ EOS;
         foreach ($js_files as $js) {
             $this->output('<script src="'. $components . $js . '"></script>');
         }
+        $this->output('<script src="'. QA_HTML_THEME_LAYER_URLTOROOT . 'js/q2a-embeds.js' . '"></script>');
     }
 
 } // end qa_html_theme_layer

--- a/q2a-medium-editor-layer.php
+++ b/q2a-medium-editor-layer.php
@@ -20,6 +20,30 @@ class qa_html_theme_layer extends qa_html_theme_base
             $this->output_js();
         }
     }
+    
+    function q_view_content($q_view)
+    {
+        if (isset($q_view['content'])){
+            $q_view['content'] = $this->embed_replace($q_view['content']);
+        }
+        qa_html_theme_base::q_view_content($q_view);
+    }
+    
+    function a_item_content($a_item)
+    {
+        if (isset($a_item['content'])) {
+            $a_item['content'] = $this->embed_replace($a_item['content']);
+        }
+        qa_html_theme_base::a_item_content($a_item);
+    }
+    
+    function c_item_content($c_item)
+    {
+        if (isset($c_item['content'])) {
+            $c_item['content'] = $this->embed_replace($c_item['content']);
+        }
+        qa_html_theme_base::c_item_content($c_item);
+    }
 
     private function output_css()
     {
@@ -64,6 +88,31 @@ EOS;
             $this->output('<script src="'. $components . $js . '"></script>');
         }
         $this->output('<script src="'. QA_HTML_THEME_LAYER_URLTOROOT . 'js/q2a-embeds.js' . '"></script>');
+    }
+    
+    private function embed_replace($text)
+    {
+        $types = array(
+            'youtube' => array(
+                array(
+                    'https{0,1}:\/\/w{0,3}\.*youtube\.com\/watch\?\S*v=([A-Za-z0-9_-]+)[^< ]*',
+                    '<iframe width="420" height="315" src="http://www.youtube.com/embed/$1?wmode=transparent" frameborder="0" allowfullscreen></iframe>'
+                ),
+                array(
+                    'https{0,1}:\/\/w{0,3}\.*youtu\.be\/([A-Za-z0-9_-]+)[^< ]*',
+                    '<iframe width="420" height="315" src="http://www.youtube.com/embed/$1?wmode=transparent" frameborder="0" allowfullscreen></iframe>'
+                ),
+            ),
+        );
+
+        foreach($types as $t => $ra) {
+            foreach($ra as $r) {
+                $text = preg_replace('/<a[^>]+>'.$r[0].'<\/a>/i',$r[1],$text);
+                $text = preg_replace('/(?<![\'"=])'.$r[0].'/i',$r[1],$text);
+            }
+        }
+        $text = preg_replace('/class="plain_url"/i','class="video video-youtube"',$text);
+        return $text;
     }
 
 } // end qa_html_theme_layer

--- a/q2a-medium-editor-layer.php
+++ b/q2a-medium-editor-layer.php
@@ -90,17 +90,17 @@ EOS;
         $this->output('<script src="'. QA_HTML_THEME_LAYER_URLTOROOT . 'js/q2a-embeds.js' . '"></script>');
     }
     
-    private function embed_replace($text)
+    function embed_replace($text)
     {
         $types = array(
             'youtube' => array(
                 array(
                     'https{0,1}:\/\/w{0,3}\.*youtube\.com\/watch\?\S*v=([A-Za-z0-9_-]+)[^< ]*',
-                    '<iframe width="420" height="315" src="http://www.youtube.com/embed/$1?wmode=transparent" frameborder="0" allowfullscreen></iframe>'
+                    '<iframe width="420" height="315" src="//www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>'
                 ),
                 array(
                     'https{0,1}:\/\/w{0,3}\.*youtu\.be\/([A-Za-z0-9_-]+)[^< ]*',
-                    '<iframe width="420" height="315" src="http://www.youtube.com/embed/$1?wmode=transparent" frameborder="0" allowfullscreen></iframe>'
+                    '<iframe width="420" height="315" src="//www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>'
                 ),
             ),
         );

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -141,7 +141,9 @@ class qa_medium_editor
                         },
                     },
                     embeds: false,
-                    embeds2: true,
+                    embeds2: {
+                        styles: null
+                    },
                 },
             });
             $('.editable').focus(function(){

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -125,7 +125,8 @@ class qa_medium_editor
             },
             paste: {
                 forcePlainText: true,
-            }
+            },
+            spellcheck: false,
         });
         $(function() {
             $('.editable').mediumInsert({

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -111,6 +111,7 @@ class qa_medium_editor
     {
         $html = '';
 
+        $content = $this->embed_replace($content);
         if(empty($format)) {
             $content = nl2br($content);
         }
@@ -139,7 +140,7 @@ class qa_medium_editor
                         },
                     },
                     embeds: false,
-                    embeds2: {},
+                    embeds2: true,
                 },
             });
             $('.editable').focus(function(){
@@ -154,7 +155,10 @@ class qa_medium_editor
         function get_content() {
             var allContents = editor.serialize();
             var editorId = editor.elements[0].id;
-            return allContents[editorId].value;
+            var content = allContents[editorId].value;
+            content = content.replace(/<div class=\"video video-youtube\">.*?<\/div>/g, '');
+            content = content.replace(/medium-insert-embeds-selected/g, '');
+            return content;
         }
         </script>";
         return array(
@@ -184,6 +188,28 @@ class qa_medium_editor
             'format' => 'html',
             'content' => qa_sanitize_html($html, false, true),
         );
+    }
+    
+    private function embed_replace($text)
+    {
+        $types = array(
+            'youtube' => array(
+                array(
+                    '(https{0,1}:\/\/w{0,3}\.*youtube\.com\/watch\?\S*v=([A-Za-z0-9_-]+))[^< ]*',
+                    '<div class="video video-youtube"><iframe width="420" height="315" src="http://www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
+                ),
+                array(
+                    'https{0,1}:\/\/w{0,3}\.*youtu\.be\/([A-Za-z0-9_-]+)[^< ]*',
+                    '<div class="video video-youtube"><iframe width="420" height="315" src="http://www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
+                ),
+            ),
+        );
+        foreach($types as $t => $ra) {
+            foreach($ra as $r) {
+                $text = preg_replace('/<div class="plain_url">'.$r[0].'<\/div>/i',$r[1],$text);
+            }
+        }
+        return $text;
     }
 }
 

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -196,11 +196,11 @@ class qa_medium_editor
             'youtube' => array(
                 array(
                     '(https{0,1}:\/\/w{0,3}\.*youtube\.com\/watch\?\S*v=([A-Za-z0-9_-]+))[^< ]*',
-                    '<div class="video video-youtube"><iframe width="420" height="315" src="http://www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
+                    '<div class="video video-youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
                 ),
                 array(
                     'https{0,1}:\/\/w{0,3}\.*youtu\.be\/([A-Za-z0-9_-]+)[^< ]*',
-                    '<div class="video video-youtube"><iframe width="420" height="315" src="http://www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
+                    '<div class="video video-youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/$2" frameborder="0" allowfullscreen></iframe></div><div class="plain_url">$1</div>'
                 ),
             ),
         );

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -139,6 +139,7 @@ class qa_medium_editor
                         },
                     },
                     embeds: false,
+                    embeds2: {},
                 },
             });
             $('.editable').focus(function(){


### PR DESCRIPTION
- 既存の insert-plugin の embeds アドオンを改造
  1. エディタでurl入力後にプレビュー表示（url -> 動画タグ変換)
  2. 保存時に scriptタグなどは削除 （urlのみ残す）
  3. 表示する時はふたたび url -> 動画タグ変換
  4. 再編集時も url -> 動画タグ変換
- ほぼ元のままの機能だが url 変換は Youtube のみ対応 
- 右寄せ左寄せは今のところOFF
- ボタンを使わずにURLを直接貼り付けた場合は、編集時の動画プレビューはできません（通常時に表示はされる）