### PR TITLE
773 質問投稿の末尾に、改行による大きなスペースができやすい

### DIFF
--- a/js/override.js
+++ b/js/override.js
@@ -8,6 +8,7 @@ function get_content(name) {
         var content = allContents[editorId].value;
         content = content.replace(/<div class=\"video video-youtube\">.*?<\/div>/g, '');
         content = content.replace(/medium-insert-embeds-selected/g, '');
+        content = content.replace(/<div class="medium-insert-buttons".*>.*<\/div>/g, '');
     } else {
         content = '';
     }

--- a/q2a-medium-editor-filter.php
+++ b/q2a-medium-editor-filter.php
@@ -1,0 +1,74 @@
+<?php
+
+	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+		header('Location: ../');
+		exit;
+	}
+
+	class q2a_medium_editor_filter {
+
+		private $directory;
+
+		function load_module($directory, $urltoroot)
+		{
+			$this->directory = $directory;
+		}
+
+		function filter_question(&$question, &$errors, $oldquestion)
+		{
+			if (qa_opt('editor_for_qs') === 'Medium Editor') {
+				$question['content'] = $this->remove_tags($question['content']);
+			}
+		}
+
+		function filter_answer(&$answer, &$errors, $question, $oldanswer)
+		{
+			if (qa_opt('editor_for_as') === 'Medium Editor') {
+				$answer['content'] = $this->remove_tags($answer['content']);
+			}
+		}
+
+		function filter_comment(&$comment, &$errors, $question, $parent, $oldcomment)
+		{
+			if (qa_opt('editor_for_cs') === 'Medium Editor') {
+				$comment['content'] = $this->remove_tags($comment['content']);
+			}
+		}
+
+		private function remove_tags($content) {
+			// remove progressbar
+			$tmp = $this->remove_progressbar($content);
+			// remove br tags at the end of contents
+			$new_content = $this->remove_br_tags($tmp);
+
+			return $new_content;
+		}
+
+		/*
+		 * プログレスバーが残っている場合に削除する
+		 */
+		private function remove_progressbar($content)
+		{
+			$regex = "/\<div\s?class=\"[^\"]*bar[^\"]*\"[^>]*><\/div>/Us";
+			$regex2 = "/\<div\s?class=\"mdl-progress\s?[^\"]*\"[^>]*><\/div>/Us";
+			$tmp = preg_replace($regex, "", $content);
+			return preg_replace($regex2, "", $tmp);
+		}
+
+		/*
+		 * 本文末尾の改行を削除
+		 */
+		private function remove_br_tags($content)
+		{
+			$regex = "/<p class=\"medium-insert-active\">(<br>)*<\/p>/Us";
+			$regex2 = "/(<p class=\"\">(<br>)*<\/p>)*$/Us";
+			$tmp = preg_replace($regex, "", $content);
+			return preg_replace($regex2, "", $tmp);
+		}
+
+	}
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -104,7 +104,6 @@ class qa_medium_editor
         $html = '';
         $placeholder = '';
 
-        $content = $this->remove_progressbar($content);
         $content = $this->embed_replace($content);
         if (empty($format)) {
             $content = nl2br($content);
@@ -197,16 +196,6 @@ class qa_medium_editor
         );
     }
 
-    /*
-     * プログレスバーが残っている場合に削除する
-     */
-    private function remove_progressbar($content)
-    {
-        $regex = "/\<div\s?class=\"[^\"]*bar[^\"]*\"[^>]*><\/div>/Us";
-        $regex2 = "/\<div\s?class=\"mdl-progress\s?[^\"]*\"[^>]*><\/div>/Us";
-        $tmp = preg_replace($regex, "", $content);
-        return preg_replace($regex2, "", $tmp);
-    }
 }
 
 /*

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -33,6 +33,9 @@
     // language file
     qa_register_plugin_phrases('q2a-medium-editor-lang-*.php', 'q2a_medium_editor_lang');
 
+    // filter module
+    qa_register_plugin_module('filter', 'q2a-medium-editor-filter.php', 'q2a_medium_editor_filter', 'Medium Editor Filter');
+
 /*
     Omit PHP closing tag to help avoid accidental output
 */


### PR DESCRIPTION
* 末尾の改行を削除する
  - フィルターで削除

* プラスボタンが残っている場合があったので削除
  - js で削除する