### PR TITLE
919 投稿の末尾に改行が多数含まれたまま投稿されてしまう

### DIFF
--- a/q2a-medium-editor-filter.php
+++ b/q2a-medium-editor-filter.php
@@ -44,21 +44,10 @@
 			// remove span style
 			$tmp = qme_remove_style('span', $tmp);
 			// remove br tags at the end of contents
-			$new_content = $this->remove_br_tags($tmp);
-
+			$new_content = qme_remove_br_tags($tmp);
 			return $new_content;
 		}
 
-		/*
-		 * 本文末尾の改行を削除
-		 */
-		private function remove_br_tags($content)
-		{
-			$regex = "/<p class=\"medium-insert-active\">(<br>)*<\/p>/Us";
-			$regex2 = "/(<p class=\"\">(<br>)*<\/p>)*$/Us";
-			$tmp = preg_replace($regex, "", $content);
-			return preg_replace($regex2, "", $tmp);
-		}
 
 	}
 

--- a/q2a-medium-editor-layer.php
+++ b/q2a-medium-editor-layer.php
@@ -227,6 +227,7 @@ class qa_html_theme_layer extends qa_html_theme_base
     {
         $tmp = qme_remove_progressbar($content);
         $tmp = qme_remove_style('span', $tmp);
+        $tmp = qme_remove_br_tags_in_div($tmp);
         $tmp = $this->remove_overlay($tmp);
         return $this->medium_editor_embed_replace($tmp);
     }

--- a/util/functions.php
+++ b/util/functions.php
@@ -38,3 +38,51 @@ function qme_remove_style($tag, $content)
 
     return $pq->html();
 }
+
+/*
+ * 本文末尾の改行を削除
+ */
+function qme_remove_br_tags($content)
+{
+    $pq = phpQuery::newDocument($content);
+
+    $elements = $pq['p'];
+
+    // 処理しやすくするためpタグ内余計なスペース削除
+    foreach ($elements as $elem) {
+        $text = pq($elem)->html();
+        pq($elem)->html( qme_mb_trim($text) );
+    }
+    $tmp = $pq->html();
+    $regex = "/<p class=\"medium-insert-active\">(<br>|\s|　)*<\/p>/Us";
+    $regex2 = "/(<p class=\"\">(<br>|\s|　)*<\/p>|\s)*$/Us";
+    $tmp = preg_replace($regex, "", $tmp);
+    return preg_replace($regex2, "", $tmp);
+}
+
+/*
+ * 文字列の前後の空白を取り除く
+ */
+ function qme_mb_trim($string)
+ {
+     $string = preg_replace( "/^[\s　]*(.*?)[\s　]*$/u", "$1", $string);
+     return $string;
+ }
+
+/*
+ * 文字列末尾の改行を削除、div で囲まれたバージョン
+ * 表示する場合 <div class="entry-content"></di> で囲まれている
+ */
+function qme_remove_br_tags_in_div($content)
+{
+    $pq = phpQuery::newDocument($content);
+
+    $elements = $pq['div.entry-content'];
+
+    foreach ($elements as $elem) {
+        $text = pq($elem)->html();
+        pq($elem)->html( qme_remove_br_tags($text) );
+    }
+
+    return $pq->html();
+}


### PR DESCRIPTION
* 文章末尾の空行を取り除く
  - `<p class=""><br></p>` だけでなく `<p class="">半角スペースor全角スペース</p>`などのパターンにも対応