### PR TITLE
866 Medium editorの画像も、動画のように表示時に展開する方式にする

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -125,3 +125,8 @@ video::-webkit-media-controls-panel {
 .medium-insert-videos-selected video {
   border: 2px solid #000;
 }
+
+/* replaced image tag */
+.medium-insert-images .image-url {
+  display: none;
+}

--- a/html/image-url.html
+++ b/html/image-url.html
@@ -1,0 +1,2 @@
+<img src="$1" />
+<div class="image-url">[image="$1"]</div>

--- a/js/q2a-images.js
+++ b/js/q2a-images.js
@@ -181,6 +181,8 @@
             var $data = $('<div />').html(data[key].value);
 
             $data.find('.medium-insert-images').find('figcaption, figure').removeAttr('contenteditable');
+            $data.find('.medium-insert-images').find('figure').find('img').remove();
+            $data.find('.medium-insert-images').find('img').remove();
             $data.find('.medium-insert-images-progress').remove();
 
             data[key].value = $data.html();
@@ -441,6 +443,10 @@
                 this.options.uploadCompleted(data.context, data);
             }
         }
+        // 画像URL用のタグを追加
+        var $imgurl = $('<div>').attr('class','image-url');
+        $imgurl.html('[image="'+img+'"]');
+        $imgurl.appendTo($place);
 
         this.core.triggerInput();
 

--- a/q2a-medium-editor-layer.php
+++ b/q2a-medium-editor-layer.php
@@ -114,6 +114,18 @@ class qa_html_theme_layer extends qa_html_theme_base
         );
         $text = preg_replace('/' . $video[0] . '/i',$video[1],$text);
 
+        // 画像タグの変換
+        error_log("DEUBG embed replace layer");
+        $imagetag = file_get_contents(MEDIUM_EDITOR_DIR . '/html/image-url.html');
+        $image = array(
+            "/\<div class=\"image-url\"\>\[image=\"\<a href=[^\>]+\>([^\"\]]+)\"\<\/a\>\]\<\/div\>/is",
+            $imagetag
+        );
+        preg_match($image[0], $text, $matches);
+        error_log($text);
+        error_log(print_r($matches, true));
+        $text = preg_replace($image[0], $image[1], $text);
+
         return $text;
     }
 

--- a/q2a-medium-editor.php
+++ b/q2a-medium-editor.php
@@ -188,6 +188,13 @@ class qa_medium_editor
         );
         $text = preg_replace('/' . $video[0] . '/i',$video[1],$text);
 
+        $imagetag = file_get_contents(MEDIUM_EDITOR_DIR . '/html/image-url.html');
+        $image = array(
+            "/\<div class=\"image-url\"\>\[image=\"([^\"\]]+)\"\]\<\/div\>/i",
+            $imagetag
+        );
+        $text = preg_replace($image[0], $image[1], $text);
+
         return $text;
     }
 


### PR DESCRIPTION
* 画像を保存するときに img タグは消す
* `<div class="image-url">[image="{src}"]</div>` を追加
* 表示するときに img タグを追加
