### PR TITLE
1300 IE11だと飼育日誌の画像が消せない

### DIFF
--- a/js/q2a-images.js
+++ b/js/q2a-images.js
@@ -146,6 +146,7 @@
             .on('click', '.medium-insert-images-toolbar2 .medium-editor-action', $.proxy(this, 'toolbar2Action'));
 
         this.$el
+            .on('mousedown', '.medium-insert-images img', $.proxy(this, 'selectImage'))
             .on('click', '.medium-insert-images img', $.proxy(this, 'selectImage'));
 
         $(window)


### PR DESCRIPTION
* IE11 だと最初のクリックで`click`イベントが発生しない
* 対策として `mousedown` でも画像を選択状態にする
  - `click`は必要なさそうだが、`mousedown` だけだとうまくいかないので残す