### PR TITLE
1368 スマホで縦長画像を投稿しようとした時に、画面の大半を画像が埋めるので操作しにくい

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -12,6 +12,7 @@
 @media (max-width: 460px) {
   .medium-insert-images figure img, .mediumInsert figure img {
     max-width: 100%;
+    max-height: 200px;
   }
 }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -9,6 +9,11 @@
 .medium-insert-images figure img, .mediumInsert figure img {
   max-width: 400px;
 }
+@media (max-width: 460px) {
+  .medium-insert-images figure img, .mediumInsert figure img {
+    max-width: 100%;
+  }
+}
 
 /* custom embed addon */
 .medium-insert-embed .plain_url {


### PR DESCRIPTION
- スマホの場合画像に max-height を設定